### PR TITLE
Magical Nightshade now plantable

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/cropspp/croploader/DreamCraftLoader.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/croploader/DreamCraftLoader.java
@@ -6,13 +6,14 @@ import com.github.bartimaeusnek.cropspp.crops.cpp.SpacePlantCrop;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.github.bartimaeusnek.cropspp.items.CppItems.ModifierMagic;
 
 public class DreamCraftLoader {
 
     public static List<CropLoader> load() {
         List<CropLoader> p = new ArrayList<CropLoader>();
         p.add(new CropLoader(new SpacePlantCrop(), null));
-        p.add(new CropLoader(new MagicModifierCrop(), null));
+        p.add(new CropLoader(new MagicModifierCrop(), ModifierMagic));
         return p;
     }
 }


### PR DESCRIPTION
You can use magic essence (obtained from primordial pearl and this crop) to plant previously unobtainable magical nightshade crop