### PR TITLE
Simplify if/else blocks for readability and to remove unreachable blocks

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicBerryCrop.java
@@ -54,18 +54,9 @@ public abstract class BasicBerryCrop extends BasicCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens quickly
-            r = 200;
-        } else {
-            // Takes a while to grow from seed
-            r = 700;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        if (crop.getSize() == 2) return 200;
+        return 700;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicDecorationCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicDecorationCrop.java
@@ -34,10 +34,7 @@ public abstract class BasicDecorationCrop extends BasicBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else
-            return 225;
+        return ConfigValues.debug ? 1 : 225;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicNetherBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicNetherBerryCrop.java
@@ -58,18 +58,8 @@ public abstract class BasicNetherBerryCrop extends BasicBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens not so quickly
-            r = 300;
-        } else {
-            // Takes a while to grow from seed
-            r = 700;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 2 ? 300 : 700;
     }
 
 }

--- a/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicThaumcraftCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicThaumcraftCrop.java
@@ -17,18 +17,8 @@ public abstract class BasicThaumcraftCrop extends BasicCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens not so quickly
-            r = 2200;
-        } else {
-            // Takes a while to grow from seed
-            r = 1800;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 2 ? 2200 : 1800;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicWitcheryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/abstracts/BasicWitcheryCrop.java
@@ -11,10 +11,7 @@ public abstract class BasicWitcheryCrop extends BasicDecorationCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else
-            return 550;
+        return ConfigValues.debug ? 1 : 550;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/BoP/BoPBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/BoP/BoPBerryCrop.java
@@ -53,18 +53,8 @@ public class BoPBerryCrop extends BasicBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens quickly
-            r = 200;
-        } else {
-            // Takes a while to grow from seed
-            r = 700;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 2 ? 200 : 700;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/BasicManaBeanCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/BasicManaBeanCrop.java
@@ -49,18 +49,8 @@ public class BasicManaBeanCrop extends BasicThaumcraftCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens not so quickly
-            r = 1200;
-        } else {
-            // Takes a while to grow from seed
-            r = 800;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 2 ? 1200 : 800;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/CinderpearlCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/CinderpearlCrop.java
@@ -34,28 +34,19 @@ public class CinderpearlCrop extends BasicThaumcraftCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 1)
-            r = 2250;
-        else if (crop.getSize() == 2 && (crop.isBlockBelow("blockBlaze") || !(OreDictionary.doesOreNameExist("blockBlaze"))))
-            r = 1750;
-        else
-            r = 250;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 1 ? 2250 : 1750;
     }
 
     @Override
     public boolean canGrow(ICropTile crop) {
-        boolean r = false;
         if (ConfigValues.debug)
-            r = crop.getSize() < 3;
-        else if (crop.getSize() <= 1)
-            r = crop.getSize() <= 1;
-        else if (crop.getSize() == 2)
-            r = (crop.getSize() == 2 && (crop.isBlockBelow("blockBlaze") || !(OreDictionary.doesOreNameExist("blockBlaze"))));
-        return r;
+            return crop.getSize() < 3;
+        if (crop.getSize() <= 1)
+            return crop.getSize() <= 1;
+        if (crop.getSize() == 2)
+            return (crop.getSize() == 2 && (crop.isBlockBelow("blockBlaze") || !(OreDictionary.doesOreNameExist("blockBlaze"))));
+        return false;
     }
 
 

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/MagicMetalBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/MagicMetalBerryCrop.java
@@ -71,16 +71,11 @@ public class MagicMetalBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        if (crop.getSize() == 2)
-            return 1200;
-        else if (crop.getSize() == 3 && (crop.isBlockBelow("blockThaumium")))
-            return 1800;
-        else if (crop.getSize() == 3 && (crop.isBlockBelow("blockVoid") || crop.isBlockBelow("blockThauminite") || crop.isBlockBelow("blockIron")))
-            return 3300;
-        else
-            return 500;
+        if (ConfigValues.debug) return 1;
+        if (crop.getSize() == 2) return 1200;
+        if (crop.getSize() == 3 && (crop.isBlockBelow("blockThaumium"))) return 1800;
+        if (crop.getSize() == 3 && (crop.isBlockBelow("blockVoid") || crop.isBlockBelow("blockThauminite") || crop.isBlockBelow("blockIron"))) return 3300;
+        return 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/PrimordialPearlBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/PrimordialPearlBerryCrop.java
@@ -61,11 +61,7 @@ public class PrimordialPearlBerryCrop extends BasicCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else {
-            return ConfigValues.PrimordialBerryGroth;
-        }
+        return ConfigValues.debug ? 1 : ConfigValues.PrimordialBerryGroth;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/ShimmerleafCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TC/ShimmerleafCrop.java
@@ -29,14 +29,8 @@ public class ShimmerleafCrop extends BasicThaumcraftCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r = 9999999;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 1)
-            r = 2250;
-        else if (crop.getSize() == 2 && (crop.isBlockBelow("blockQuicksilver") || !OreDictionary.doesOreNameExist("blockQuicksilver")))
-            r = 1750;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == 1 ? 2250 : 1750;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/AluminiumOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/AluminiumOreBerryCrop.java
@@ -32,22 +32,9 @@ public class AluminiumOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2) {
-
-            // Ripens "quickly"
-            r = 3000;
-        } else if (crop.getSize() == 3 && crop.isBlockBelow("blockAluminium"))
-            r = 1500;
-        else {
-            // Takes a while to grow from seed
-            r = 500;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
         }
-        return r;
-    }
 
     @Override
     public String[] attributes() {

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/CopperOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/CopperOreBerryCrop.java
@@ -32,22 +32,8 @@ public class CopperOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2) {
-
-            // Ripens "quickly"
-            r = 3000;
-        } else if (crop.getSize() == 3 && crop.isBlockBelow("blockCopper"))
-            r = 1500;
-        else {
-            // Takes a while to grow from seed
-            r = 500;
-        }
-
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/EssenceOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/EssenceOreBerryCrop.java
@@ -34,21 +34,8 @@ public class EssenceOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2) {
-
-            // Ripens "quickly"
-            r = 3000;
-        } else if (crop.getSize() == 3 && crop.isBlockBelow("itemSkull"))
-            r = 1500;
-        else {
-            // Takes a while to grow from seed
-            r = 500;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/GoldOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/GoldOreBerryCrop.java
@@ -32,21 +32,8 @@ public class GoldOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2) {
-
-            // Ripens "quickly"
-            r = 3000;
-        } else if (crop.getSize() == 3 && crop.isBlockBelow("blockGold"))
-            r = 1500;
-        else {
-            // Takes a while to grow from seed
-            r = 500;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/IronOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/IronOreBerryCrop.java
@@ -32,21 +32,8 @@ public class IronOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2) {
-
-            // Ripens "quickly"
-            r = 3000;
-        } else if (crop.getSize() == 3 && crop.isBlockBelow("blockIron"))
-            r = 1500;
-        else {
-            // Takes a while to grow from seed
-            r = 500;
-        }
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/TinOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/TinOreBerryCrop.java
@@ -37,19 +37,8 @@ public class TinOreBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-            // Same growth stages as melons and pumpkins
-        else if (crop.getSize() >= 2)
-            // Ripens "quickly"
-            r = 3000;
-        else if (crop.getSize() == 3 && crop.isBlockBelow("blockTin"))
-            r = 1500;
-        else
-            // Takes a while to grow from seed
-            r = 500;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TF/KnighmetalCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TF/KnighmetalCrop.java
@@ -39,19 +39,8 @@ public class KnighmetalCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() >= 2) {
-            r = 4500;
-        } else if (crop.getSize() == 3 && (crop.isBlockBelow("blockKnightmetal") || !OreDictionary.doesOreNameExist("blockKnightmetal")))
-            r = 3000;
-        else {
-            // Takes a while to grow from seed
-            r = 1000;
-        }
-
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 4500 : 1000;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/ArditeBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/ArditeBerryCrop.java
@@ -38,16 +38,8 @@ public class ArditeBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2)
-            r = 3000;
-        else if (crop.getSize() == 3 && crop.isBlockBelow("blockArdite"))
-            r = 3000;
-        else
-            r = 500;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/CobaltBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/CobaltBerryCrop.java
@@ -40,16 +40,8 @@ public class CobaltBerryCrop extends BasicTinkerBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2)
-            r = 3000;
-        else if ((crop.getSize() == 3 && crop.isBlockBelow("blockCobalt")))
-            r = 3000;
-        else
-            r = 500;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() >= 2 ? 3000 : 500;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/GoldfishCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/GoldfishCrop.java
@@ -42,10 +42,7 @@ public class GoldfishCrop extends BasicDecorationCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else
-            return 225;
+        return ConfigValues.debug ? 1 : 225;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/MagicModifierCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/MagicModifierCrop.java
@@ -43,11 +43,7 @@ public class MagicModifierCrop extends PrimordialPearlBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else {
-            return ConfigValues.PrimordialBerryGroth / 16;
-        }
+        return ConfigValues.debug ? 1 : ConfigValues.PrimordialBerryGroth / 16;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/SpacePlantCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/SpacePlantCrop.java
@@ -23,9 +23,7 @@ public class SpacePlantCrop extends BasicCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        return 5000;
+        return ConfigValues.debug ? 1 : 5000;
     }
 
 

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/WaterlillyCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/cpp/WaterlillyCrop.java
@@ -28,12 +28,8 @@ public class WaterlillyCrop extends BasicDecorationCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int ret = 550;
-        if (crop.isBlockBelow(Blocks.water) || crop.isBlockBelow(Blocks.flowing_water))
-            ret = 225;
-        if (ConfigValues.debug)
-            ret = 1;
-        return ret;
+        if (ConfigValues.debug) return 1;
+        return crop.isBlockBelow(Blocks.water) || crop.isBlockBelow(Blocks.flowing_water) ? 225 : 550;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/gregtechCrops/GarnydniaCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/gregtechCrops/GarnydniaCrop.java
@@ -74,14 +74,9 @@ public class GarnydniaCrop extends BasicCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else if (crop.getSize() == 0)
-            return 3300;
-        else if (crop.getSize() == this.maxSize() - 1)
-            return 550;
-        else
-            return 300;
+        if (ConfigValues.debug) return 1;
+        if (crop.getSize() == 0) return 3300;
+        return crop.getSize() == this.maxSize() - 1 ? 550 : 300;
     }
 
     public List<String> getCropInformation() {

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/gregtechCrops/StonelillyCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/gregtechCrops/StonelillyCrop.java
@@ -51,12 +51,8 @@ public class StonelillyCrop extends BasicDecorationCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        if (ConfigValues.debug)
-            return 1;
-        else if (crop.getSize() == (this.maxSize() - 1) && crop.isBlockBelow(Blocks.end_stone))
-            return 550;
-        else
-            return 300;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() == (this.maxSize() - 1) && crop.isBlockBelow(Blocks.end_stone) ? 550 : 300;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/SaguaroCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/SaguaroCrop.java
@@ -43,14 +43,8 @@ public class SaguaroCrop extends CactiCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() > 2)
-            r = 450;
-        else
-            r = 225;
-        return r;
+        if (ConfigValues.debug) return 1;
+        return crop.getSize() > 2 ? 450 : 225;
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/nether/BasicNetherShroomCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/nether/BasicNetherShroomCrop.java
@@ -49,19 +49,7 @@ public class BasicNetherShroomCrop extends BasicNetherBerryCrop {
 
     @Override
     public int growthDuration(ICropTile crop) {
-        int r;
-        // Same growth stages as melons and pumpkins
-        if (ConfigValues.debug)
-            r = 1;
-        else if (crop.getSize() == 2) {
-            // Ripens not so quickly
-            r = 250;
-        } else {
-            // Takes a while to grow from seed
-            r = 600;
-        }
-        return r;
-
+        return ConfigValues.debug ? 1 : 600;
     }
 
     @Override


### PR DESCRIPTION
Goal is to improve readability.  I removed else if branches that could never be reached and simplified a lot of them to ?: statements.  BasicNetherShroomCrop was reduced to a single line because they only have 2 total stages, so there is no growth stage 2.  Also removed the block checks in the growthDuration methods because those are already handled by canGrow().  