### PR TITLE
Fix Essence Berry

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,6 +25,7 @@ dependencies {
     //runtimeOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     //runtimeOnly("com.github.GTNewHorizons:twilightforest:2.6.34:dev")
     //runtimeOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.10-GTNH:dev")
+    //runtimeOnly("com.github.GTNewHorizons:EnderIO:2.8.18:dev")
     //runtimeOnly("com.github.GTNewHorizons:Natura:2.7.3:dev")
     //runtimeOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.56:dev")
     //runtimeOnly("com.github.GTNewHorizons:Galacticraft:3.2.5-GTNH:dev")

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/BasicTConstructOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/BasicTConstructOreBerryCrop.java
@@ -21,9 +21,13 @@ public abstract class BasicTConstructOreBerryCrop extends BasicTinkerBerryCrop {
         return crop.getSize() >= this.maxSize() - 2 ? 3000 : 500;
     }
 
+    public boolean isBlockBelow(ICropTile crop) {
+        return crop.isBlockBelow(hasBlock());
+    }
+
     @Override
     public ItemStack getGain(ICropTile crop) {
-        return getDropItem(crop.getSize() >= this.maxSize() && crop.isBlockBelow(hasBlock()) ? 6 : 2);
+        return getDropItem(crop.getSize() >= this.maxSize() && this.isBlockBelow(crop) ? 6 : 2);
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/EssenceOreBerryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/TConstruct/EssenceOreBerryCrop.java
@@ -1,5 +1,6 @@
 package com.github.bartimaeusnek.cropspp.crops.TConstruct;
 
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 import ic2.api.crops.ICropTile;
@@ -24,6 +25,14 @@ public class EssenceOreBerryCrop extends BasicTConstructOreBerryCrop {
     @Override
     protected String hasBlock() {
         return "itemSkull";
+    }
+
+    @Override
+    public boolean isBlockBelow(ICropTile crop) {
+        // IC2 doesn't understand wildcards in its item comparison logic for block below checks.
+        // So I'm using a workaround for vanilla skulls. EIO also adds a it's endermand head to the list and since that
+        // doesn't use a wild card we can assume it that should keep working.
+        return crop.isBlockBelow(Blocks.skull) || super.isBlockBelow(crop);
     }
 
     @Override


### PR DESCRIPTION
This commit will address https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17515

IC2 causes the issue since it doesn't account for wildcards when checking for ore dictionaries. EnderIO (added as an optional runtime dependency) registers the itemSkull oredict and uses a wildcard for the metadata of the vanilla skulls.

This may affect balance since the check has only ever worked if you used EIO's Enderman head as the block since that one isn't stored in the oredict with a wildcard.