### PR TITLE
Remove SPOOKY from Biome Humidity List

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/cropspp/BiomeHumidityBonus.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/BiomeHumidityBonus.java
@@ -17,7 +17,6 @@ public class BiomeHumidityBonus {
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.SAVANNA, -5);
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.CONIFEROUS, 7);
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.JUNGLE, 10);
-        Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.SPOOKY, 7);
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.DEAD, -5);
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.LUSH, 7);
         Crops.instance.addBiomehumidityBonus(BiomeDictionary.Type.NETHER, -10);


### PR DESCRIPTION
Crops++ would make `SPOOKY` type biomes very humid, which would break the common sense in most of those biomes.
Here's the list of the related biomes.

In IC2, the crops humid calculating would use code like this
```
  public int getHumidityBiomeBonus(BiomeGenBase biome) {
    Integer ret = Integer.valueOf(0);
    for (BiomeDictionary.Type type : BiomeDictionary.getTypesForBiome(biome)) {
      Integer val = this.humidityBiomeTypeBonus.get(type);
      if (val != null && val.intValue() > ret.intValue())
        ret = val; 
    } 
    return ret.intValue();
  }
```
So it would always use the highest humidity value inside the biome type list.



For keyword `SPOOKY`, the humid bonus was set to 7 in crops++, and this is not good at all.

Related biomes:
Nether Biome or Wasteland,
`NETHER(-10)`, `WASTELAND(-5)`,`SANDY(-5)` and `SPARSE(-5)` are all considered to be a dry keyword. Due to the IC2 algorithm, `SPOOKY(7)` would win, and make it out a humid environment.
```
Visceral Heap, ["SPOOKY", "NETHER"]
Wasteland, ["SPARSE", "SPOOKY", "DEAD", "WASTELAND"]
Boneyard, ["SPOOKY", "NETHER", "WASTELAND"]
Corrupted Sands, ["SPOOKY", "NETHER", "SANDY"]
Phantasmagoric Inferno, ["SPOOKY", "NETHER"]
Undergarden, ["JUNGLE", "SPOOKY", "NETHER"]
```

Galaxy Space related Biomes:
These biomes all have keywords as `COLD(-5)`, `DRY(-10)` and `DEAD(-5)`, so they should all be considered to be dry. Due to the IC2 algorithm, `SPOOKY(7)` would win, and make it out a humid environment.
```
asteroids, ["COLD", "DRY", "SPOOKY", "DEAD"]
Space, ["COLD", "DRY", "SPOOKY", "DEAD"]
Venus, ["COLD", "DRY", "SPOOKY", "DEAD"]
Pluto, ["COLD", "DRY", "SPOOKY", "DEAD"]
Pluto2, ["COLD", "DRY", "SPOOKY", "DEAD"]
Pluto3, ["COLD", "DRY", "SPOOKY", "DEAD"]
Pluto4, ["COLD", "DRY", "SPOOKY", "DEAD"]
Kuiper Belt, ["COLD", "DRY", "SPOOKY", "DEAD"]
Io, ["COLD", "DRY", "SPOOKY", "DEAD"]
IoAsh, ["COLD", "DRY", "SPOOKY", "DEAD"]
Titan, ["COLD", "DRY", "SPOOKY", "DEAD"]
BarnardaCShores, ["COLD", "DRY", "SPOOKY", "DEAD"]
BarnardaCHills, ["COLD", "DRY", "SPOOKY", "DEAD"]
BarnardaCLowPlains, ["COLD", "DRY", "SPOOKY", "DEAD"]
BarnardaCFlowers, ["COLD", "DRY", "SPOOKY", "DEAD"]
TCetiE, ["COLD", "DRY", "SPOOKY", "DEAD"]
```

Data are actually coming from [https://github.com/cubic-chariot/ic2crops/blob/master/src/BiomeData.ts](https://github.com/cubic-chariot/ic2crops/blob/master/src/BiomeData.ts)