### PR TITLE
Make Spade behave more like a vanilla Hoe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,16 +4,16 @@ dependencies {
     api("com.github.GTNewHorizons:CropLoadCore:0.2.0:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.49:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.61:dev")
     compileOnly(deobf("https://media.forgecdn.net/files/2499/612/BiomesOPlenty-1.7.10-2.1.0.2308-universal.jar"))
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.6.34:dev") {
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.6.35:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.12-GTNH:dev")
-    compileOnly("com.github.GTNewHorizons:Natura:2.7.4:dev") {
+    compileOnly("com.github.GTNewHorizons:Natura:2.7.5:dev") {
         transitive = false
     }
-    compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.68:dev") {
+    compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.74:dev") {
         transitive = false
     }
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.2.5-GTNH:dev") {
@@ -23,10 +23,10 @@ dependencies {
 
     // for testing
     //runtimeOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
-    //runtimeOnly("com.github.GTNewHorizons:twilightforest:2.6.34:dev")
+    //runtimeOnly("com.github.GTNewHorizons:twilightforest:2.6.35:dev")
     //runtimeOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.12-GTNH:dev")
-    //runtimeOnly("com.github.GTNewHorizons:EnderIO:2.8.19:dev")
-    //runtimeOnly("com.github.GTNewHorizons:Natura:2.7.4:dev")
-    //runtimeOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.68:dev")
+    //runtimeOnly("com.github.GTNewHorizons:EnderIO:2.8.20:dev")
+    //runtimeOnly("com.github.GTNewHorizons:Natura:2.7.5:dev")
+    //runtimeOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.74:dev")
     //runtimeOnly("com.github.GTNewHorizons:Galacticraft:3.2.5-GTNH:dev")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
 }
 
 


### PR DESCRIPTION
In GTNH, using a hoe, it will not turn a dirt block into farmland if it's outside of water range, however, the spade bypassed this since it does not generate `UseHoeEvent` through which the mentioned behavior is implemented. This PR makes the tool behave more like the vanilla hoe and fires the event in addition for make the same sounds now.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17927