### PR TITLE
Fix Typo for Natura Blueberry

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/BlueberryCrop.java
+++ b/src/main/java/com/github/bartimaeusnek/cropspp/crops/natura/BlueberryCrop.java
@@ -13,7 +13,7 @@ import mods.natura.common.NContent;
 
 public class BlueberryCrop extends BasicBerryCrop {
 
-    private static final String cropOreName = "cropCotton";
+    private static final String cropOreName = "cropBlueberry";
 
     public BlueberryCrop() {
         super();


### PR DESCRIPTION
cropOreName of Blueberry was Cotton, which is a clear typo
now it can be placed on crop sticks again
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15657