### PR TITLE
chore: fix build by updating the BOP link

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
     devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.176:dev")
-    compileOnly(deobf("https://media.forgecdn.net/files/2499/612/BiomesOPlenty-1.7.10-2.1.0.2308-universal.jar"))
+    compileOnly(deobf("https://mediafilez.forgecdn.net/files/2499/612/BiomesOPlenty-1.7.10-2.1.0.2308-universal.jar"))
     compileOnly("com.github.GTNewHorizons:twilightforest:2.7.5:dev") {
         transitive = false
     }


### PR DESCRIPTION
Fixes this build error: 

```
An exception occurred applying plugin request [id: 'com.gtnewhorizons.gtnhconvention']
Failed to apply plugin 'com.gtnewhorizons.gtnhconvention'.
A problem occurred evaluating script.
de.undercouch.gradle.tasks.download.org.apache.hc.client5.http.ClientProtocolException: Forbidden (HTTP status code: 403, URL: https://media.forgecdn.net/files/2499/612/BiomesOPlenty-1.7.10-2.1.0.2308-universal.jar)
```